### PR TITLE
feat: add voice SDK wrapper and demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /node_modules/
 /lib-es5/
+packages/*/node_modules/
+packages/*/dist/
+examples/*/node_modules/

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "semi": true,
+  "printWidth": 80
+}

--- a/docs/asterisk.md
+++ b/docs/asterisk.md
@@ -1,0 +1,41 @@
+# Asterisk Configuration Guide
+
+Example minimal configuration for WebRTC clients.
+
+## `http.conf`
+
+```
+wss_port = 8089
+```
+
+## `pjsip.conf`
+
+```
+[transport-wss]
+type=transport
+protocol=wss
+bind=0.0.0.0
+
+[webrtc-client]
+type=endpoint
+aors=webrtc-client
+auth=webrtc-client
+use_avpf=yes
+media_encryption=dtls
+transport=transport-wss
+rtp_symmetric=yes
+force_rport=yes
+direct_media=no
+codecs=opus,ulaw
+
+[webrtc-client]
+type=aor
+contact=sip:webrtc-client@domain
+
+[webrtc-client]
+type=auth
+auth_type=userpass
+username=webrtc-client
+password=secret
+```
+

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,5 @@
+# Security Notes
+
+- Use HTTPS and WSS only.
+- Tokens should be short lived.
+- Do not log SIP passwords.

--- a/examples/minimal-webapp/README.md
+++ b/examples/minimal-webapp/README.md
@@ -1,0 +1,9 @@
+# Minimal Web App
+
+Example using `@company/voice-sdk`.
+
+```bash
+pnpm install
+pnpm --filter @company/voice-sdk build
+pnpm --filter minimal-webapp dev
+```

--- a/examples/minimal-webapp/index.html
+++ b/examples/minimal-webapp/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Voice SDK Demo</title>
+  </head>
+  <body>
+    <h1>Voice SDK Demo</h1>
+    <input id="token" placeholder="Token" />
+    <button id="init">Init</button>
+    <input id="target" placeholder="Target" />
+    <button id="call">Call</button>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/examples/minimal-webapp/package.json
+++ b/examples/minimal-webapp/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "minimal-webapp",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@company/voice-sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "vite": "^5.1.0",
+    "typescript": "^5.4.2"
+  }
+}

--- a/examples/minimal-webapp/src/main.ts
+++ b/examples/minimal-webapp/src/main.ts
@@ -1,0 +1,16 @@
+import { VoiceSDK } from '@company/voice-sdk';
+
+let sdk: VoiceSDK | undefined;
+
+document.getElementById('init')?.addEventListener('click', async () => {
+  const token = (document.getElementById('token') as HTMLInputElement).value;
+  sdk = new VoiceSDK({ token, authServer: 'https://auth.example.com' });
+  await sdk.init();
+  alert('SDK ready');
+});
+
+document.getElementById('call')?.addEventListener('click', async () => {
+  if (!sdk) return;
+  const target = (document.getElementById('target') as HTMLInputElement).value;
+  await sdk.call({ target });
+});

--- a/examples/minimal-webapp/tsconfig.json
+++ b/examples/minimal-webapp/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "types": ["vite/client"]
+  }
+}

--- a/examples/minimal-webapp/vite.config.ts
+++ b/examples/minimal-webapp/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  root: '.',
+  server: { port: 5173 }
+});

--- a/packages/voice-sdk/.eslintrc.cjs
+++ b/packages/voice-sdk/.eslintrc.cjs
@@ -1,0 +1,11 @@
+module.exports = {
+  parser: '@typescript-eslint/parser',
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'prettier'],
+  plugins: ['@typescript-eslint'],
+  root: true,
+  env: { browser: true, es2020: true },
+  ignorePatterns: ['dist'],
+  rules: {
+    '@typescript-eslint/no-explicit-any': 'error'
+  }
+};

--- a/packages/voice-sdk/API.md
+++ b/packages/voice-sdk/API.md
@@ -1,0 +1,21 @@
+# Voice SDK API
+
+## `class VoiceSDK`
+
+### constructor(options: VoiceSDKOptions)
+Create instance with auth token and server.
+
+### `init(): Promise<void>`
+Fetch credentials and register with SIP server.
+
+### `call(options: CallOptions): Promise<CallSession>`
+Start an outbound call.
+
+### `getActiveSessions(): CallSession[]`
+List active calls.
+
+### `on(event, handler)`
+Subscribe to events.
+
+### `destroy(): Promise<void>`
+Stop UA and clear sessions.

--- a/packages/voice-sdk/LICENSE
+++ b/packages/voice-sdk/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Company
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/voice-sdk/README.md
+++ b/packages/voice-sdk/README.md
@@ -1,0 +1,21 @@
+# Voice SDK
+
+A TypeScript SDK wrapping [JsSIP](https://jssip.net) to place and receive SIP calls over WebRTC.
+
+## Quick Start
+
+```bash
+npm install @company/voice-sdk
+```
+
+```ts
+import { VoiceSDK } from '@company/voice-sdk';
+
+const sdk = new VoiceSDK({
+  token: 'TOKEN',
+  authServer: 'https://auth.example.com'
+});
+
+await sdk.init();
+await sdk.call({ target: '1001' });
+```

--- a/packages/voice-sdk/package.json
+++ b/packages/voice-sdk/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@company/voice-sdk",
+  "version": "1.0.0",
+  "description": "Voice SDK wrapping JsSIP for WebRTC SIP calls",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json && rollup -c",
+    "lint": "eslint src --ext .ts",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "jssip": "^3.10.1",
+    "zod": "^3.22.2",
+    "eventemitter3": "^5.0.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.2",
+    "rollup": "^3.29.4",
+    "rollup-plugin-dts": "^5.3.0",
+    "@rollup/plugin-node-resolve": "^15.2.1",
+    "@rollup/plugin-commonjs": "^24.0.1",
+    "@rollup/plugin-typescript": "^11.1.2",
+    "eslint": "^8.57.0",
+    "@typescript-eslint/parser": "^7.1.1",
+    "@typescript-eslint/eslint-plugin": "^7.1.1",
+    "prettier": "^3.2.5",
+    "vitest": "^1.3.0",
+    "eslint-config-prettier": "^9.1.0"
+  }
+}

--- a/packages/voice-sdk/rollup.config.mjs
+++ b/packages/voice-sdk/rollup.config.mjs
@@ -1,0 +1,24 @@
+import path from 'path';
+import resolve from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
+import typescript from '@rollup/plugin-typescript';
+import dts from 'rollup-plugin-dts';
+
+const input = 'src/index.ts';
+
+export default [
+  {
+    input,
+    output: [
+      { file: 'dist/index.js', format: 'esm', sourcemap: true },
+      { file: 'dist/index.cjs', format: 'cjs', sourcemap: true }
+    ],
+    plugins: [resolve(), commonjs(), typescript({ tsconfig: './tsconfig.json' })],
+    external: ['jssip', 'eventemitter3', 'zod']
+  },
+  {
+    input,
+    output: { file: 'dist/index.d.ts', format: 'esm' },
+    plugins: [dts()]
+  }
+];

--- a/packages/voice-sdk/src/AuthClient.ts
+++ b/packages/voice-sdk/src/AuthClient.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod';
+
+export const credentialSchema = z.object({
+  username: z.string(),
+  domain: z.string(),
+  password: z.string(),
+  wssUrl: z.string().url(),
+  registrar: z.string().optional(),
+  outboundProxy: z.string().optional(),
+  displayName: z.string().optional(),
+  stunServers: z.array(z.string()).optional(),
+  turnServers: z
+    .array(
+      z.object({
+        urls: z.array(z.string()),
+        username: z.string(),
+        credential: z.string()
+      })
+    )
+    .optional()
+});
+
+export type CredentialResponse = z.infer<typeof credentialSchema>;
+
+export async function fetchCredentials(
+  authServer: string,
+  token: string
+): Promise<CredentialResponse> {
+  const res = await fetch(`${authServer}/sip-credentials`, {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+
+  if (!res.ok) {
+    throw new Error(`Auth failed with status ${res.status}`);
+  }
+
+  const data = await res.json();
+  return credentialSchema.parse(data);
+}

--- a/packages/voice-sdk/src/errors.ts
+++ b/packages/voice-sdk/src/errors.ts
@@ -1,0 +1,17 @@
+export type SDKErrorCode =
+  | 'AUTH_FAILED'
+  | 'WSS_CONNECT_FAILED'
+  | 'REGISTRATION_FAILED'
+  | 'MEDIA_PERMISSION_DENIED'
+  | 'CALL_FAILED';
+
+export class SDKError extends Error {
+  public readonly code: SDKErrorCode;
+  public readonly cause?: unknown;
+
+  constructor(code: SDKErrorCode, message: string, cause?: unknown) {
+    super(message);
+    this.code = code;
+    this.cause = cause;
+  }
+}

--- a/packages/voice-sdk/src/index.ts
+++ b/packages/voice-sdk/src/index.ts
@@ -1,0 +1,188 @@
+import JsSIP from 'jssip';
+import EventEmitter from 'eventemitter3';
+import { fetchCredentials } from './AuthClient';
+import { SDKError } from './errors';
+import type {
+  VoiceSDKOptions,
+  CallOptions,
+  VoiceSDKEvents,
+  CallSession,
+  CallState
+} from './types';
+import type { UAConfiguration } from 'jssip/lib/UA';
+import type { RTCSession } from 'jssip/lib/RTCSession';
+
+class SimpleCallSession implements CallSession {
+  public id: string;
+  public direction: 'inbound' | 'outbound';
+  public state: CallState = 'new';
+  constructor(private session: RTCSession, direction: 'inbound' | 'outbound') {
+    this.id = session.id;
+    this.direction = direction;
+  }
+  async answer(): Promise<void> {
+    this.session.answer();
+    this.state = 'established';
+  }
+  async hangup(): Promise<void> {
+    this.session.terminate();
+    this.state = 'ended';
+  }
+  async hold(): Promise<void> {
+    this.session.hold();
+    this.state = 'held';
+  }
+  async resume(): Promise<void> {
+    this.session.unhold();
+    this.state = 'established';
+  }
+  async mute(): Promise<void> {
+    this.session.mute();
+    this.state = 'muted';
+  }
+  async unmute(): Promise<void> {
+    this.session.unmute();
+    this.state = 'established';
+  }
+  async sendDTMF(tone: string): Promise<void> {
+    this.session.sendDTMF(tone);
+  }
+  async transfer(target: string): Promise<void> {
+    this.session.refer(target);
+  }
+}
+
+type EventMap = { [K in keyof VoiceSDKEvents]: [VoiceSDKEvents[K]] };
+
+export class VoiceSDK {
+  private opts: VoiceSDKOptions;
+  private ua?: JsSIP.UA;
+  private emitter = new EventEmitter<EventMap>();
+  private sessions = new Map<string, SimpleCallSession>();
+  private domain?: string;
+
+  constructor(opts: VoiceSDKOptions) {
+    this.opts = opts;
+  }
+
+  async init(): Promise<void> {
+    try {
+      const creds = await fetchCredentials(this.opts.authServer, this.opts.token);
+      this.domain = creds.domain;
+      const socket = new JsSIP.WebSocketInterface(creds.wssUrl);
+      const configuration: UAConfiguration = {
+        sockets: [socket],
+        uri: `sip:${creds.username}@${creds.domain}`,
+        password: creds.password,
+        session_timers: false,
+        registrar_server: creds.registrar,
+        display_name: creds.displayName ?? this.opts.sip?.displayName,
+        user_agent: this.opts.sip?.userAgentString
+      };
+      this.ua = new JsSIP.UA(configuration);
+      this.attachUaHandlers();
+      this.ua.start();
+      this.emitter.emit('connectionChanged', { state: 'connecting' });
+    } catch (err) {
+      throw new SDKError('AUTH_FAILED', 'Failed to initialize', err);
+    }
+  }
+
+  private attachUaHandlers(): void {
+    if (!this.ua) return;
+    this.ua.on('connected', () =>
+      this.emitter.emit('connectionChanged', { state: 'connected' })
+    );
+    this.ua.on('disconnected', () =>
+      this.emitter.emit('connectionChanged', { state: 'disconnected' })
+    );
+    this.ua.on('registered', () =>
+      this.emitter.emit('registrationChanged', { state: 'registered' })
+    );
+    this.ua.on('unregistered', () =>
+      this.emitter.emit('registrationChanged', { state: 'unregistered' })
+    );
+    this.ua.on('registrationFailed', ({ cause }: { cause?: string }) =>
+      this.emitter.emit('registrationChanged', {
+        state: 'failed',
+        reason: cause
+      })
+    );
+    this.ua.on(
+      'newRTCSession',
+      ({ session, originator }: { session: RTCSession; originator: string }) => {
+        const direction = originator === 'local' ? 'outbound' : 'inbound';
+        const call = new SimpleCallSession(session, direction);
+        this.sessions.set(call.id, call);
+        if (direction === 'inbound') {
+          const from = session.remote_identity.uri.toString();
+          this.emitter.emit('incomingCall', { session: call, from });
+        }
+        session.on('ended', () => {
+          call.state = 'ended';
+          this.emitter.emit('callUpdated', { session: call, state: 'ended' });
+          this.sessions.delete(call.id);
+        });
+        session.on('failed', (e: { cause: string }) => {
+          call.state = 'failed';
+          this.emitter.emit('callUpdated', {
+            session: call,
+            state: 'failed',
+            reason: e.cause
+          });
+          this.sessions.delete(call.id);
+        });
+        session.on('confirmed', () => {
+          call.state = 'established';
+          this.emitter.emit('callUpdated', {
+            session: call,
+            state: 'established'
+          });
+        });
+      }
+    );
+  }
+
+  async call(options: CallOptions): Promise<CallSession> {
+    if (!this.ua) throw new SDKError('WSS_CONNECT_FAILED', 'UA not initialized');
+    const domain = this.domain ?? 'localhost';
+    const target = options.target.includes('sip:')
+      ? options.target
+      : `sip:${options.target}@${domain}`;
+    const session = this.ua.call(target, {
+      extraHeaders: options.extraHeaders,
+      mediaConstraints: { audio: true, video: false }
+    });
+    const call = new SimpleCallSession(session, 'outbound');
+    this.sessions.set(call.id, call);
+    return call;
+  }
+
+  getActiveSessions(): CallSession[] {
+    return Array.from(this.sessions.values());
+  }
+
+  on<E extends keyof VoiceSDKEvents>(
+    event: E,
+    handler: (p: VoiceSDKEvents[E]) => void
+  ): () => void {
+    this.emitter.on(event, handler as (...args: EventMap[E]) => void);
+    return () => this.emitter.off(event, handler as (...args: EventMap[E]) => void);
+  }
+
+  async destroy(): Promise<void> {
+    if (this.ua) {
+      this.ua.stop();
+      this.ua = undefined;
+    }
+    this.sessions.clear();
+  }
+}
+
+export type {
+  VoiceSDKOptions,
+  CallOptions,
+  VoiceSDKEvents,
+  CallSession,
+  CallState
+} from './types';

--- a/packages/voice-sdk/src/types.ts
+++ b/packages/voice-sdk/src/types.ts
@@ -1,0 +1,74 @@
+
+export interface VoiceSDKOptions {
+  token: string;
+  authServer: string;
+  ice?: {
+    stun?: string[];
+    turn?: { urls: string[]; username: string; credential: string }[];
+    trickle?: boolean;
+  };
+  media?: {
+    audioInputId?: string;
+    outputDeviceId?: string;
+    constraints?: MediaTrackConstraints;
+  };
+  sip?: {
+    displayName?: string;
+    userAgentString?: string;
+    registerExpiresSec?: number;
+    keepAliveIntervalSec?: number;
+    outboundProxy?: string;
+    registrar?: string;
+  };
+  logging?: 'none' | 'error' | 'info' | 'debug';
+}
+
+export interface CallOptions {
+  target: string;
+  withEarlyMedia?: boolean;
+  dtmfMode?: 'RFC2833' | 'SIP_INFO';
+  extraHeaders?: string[];
+}
+
+export type CallState =
+  | 'new'
+  | 'ringing'
+  | 'established'
+  | 'held'
+  | 'muted'
+  | 'ended'
+  | 'failed';
+
+export interface VoiceSDKEvents {
+  ready: void;
+  connectionChanged: {
+    state: 'connecting' | 'connected' | 'disconnected' | 'reconnecting';
+  };
+  registrationChanged: {
+    state: 'registered' | 'unregistered' | 'failed';
+    reason?: string;
+  };
+  incomingCall: { session: CallSession; from: string; displayName?: string };
+  callUpdated: { session: CallSession; state: CallState; reason?: string };
+  deviceChanged: {
+    microphones: MediaDeviceInfo[];
+    speakers: MediaDeviceInfo[];
+  };
+  error: { code: string; message: string; cause?: unknown };
+}
+
+export interface CallSession {
+  id: string;
+  direction: 'inbound' | 'outbound';
+  state: CallState;
+  localStream?: MediaStream;
+  remoteStream?: MediaStream;
+  answer(options?: { audio?: boolean }): Promise<void>;
+  hangup(): Promise<void>;
+  hold(): Promise<void>;
+  resume(): Promise<void>;
+  mute(): Promise<void>;
+  unmute(): Promise<void>;
+  sendDTMF(tone: string): Promise<void>;
+  transfer(target: string): Promise<void>;
+}

--- a/packages/voice-sdk/test/AuthClient.test.ts
+++ b/packages/voice-sdk/test/AuthClient.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { credentialSchema } from '../src/AuthClient';
+
+describe('credentialSchema', () => {
+  it('validates correct data', () => {
+    const data = {
+      username: 'alice',
+      domain: 'example.com',
+      password: 'pass',
+      wssUrl: 'wss://example.com/ws'
+    };
+    expect(() => credentialSchema.parse(data)).not.toThrow();
+  });
+
+  it('fails on invalid url', () => {
+    const data = {
+      username: 'alice',
+      domain: 'example.com',
+      password: 'pass',
+      wssUrl: 'not-a-url'
+    };
+    expect(() => credentialSchema.parse(data)).toThrow();
+  });
+});

--- a/packages/voice-sdk/tsconfig.json
+++ b/packages/voice-sdk/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - 'packages/*'
+  - 'examples/*'

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
## Summary
- add TypeScript VoiceSDK wrapper around JsSIP
- scaffold minimal Vite demo app
- include basic docs for Asterisk and security

## Testing
- `pnpm --filter @company/voice-sdk lint`
- `pnpm --filter @company/voice-sdk typecheck`
- `pnpm --filter @company/voice-sdk test`
- `pnpm --filter @company/voice-sdk build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b11081bfc08328b0bb4f6e63344e0d